### PR TITLE
Configure aws firelens to send logs to Oodle in task definition

### DIFF
--- a/deploy/terraform/lib/ecs/service/ecs.tf
+++ b/deploy/terraform/lib/ecs/service/ecs.tf
@@ -63,7 +63,7 @@ resource "aws_ecs_task_definition" "this" {
           "Host": "${var.oodle_log_collector_host}",
           "Port": "443",
           "URI": "/ingest/v1/logs",
-          "Header": "X-OODLE-INSTANCE-API-KEY ${var.oodle_instance}",
+          "Header": "X-OODLE-INSTANCE-API-KEY ${var.oodle_instance_api_key}",
           "Format": "json",
           "Compress": "gzip",
           "Json_date_key": "timestamp",

--- a/deploy/terraform/lib/ecs/service/ecs.tf
+++ b/deploy/terraform/lib/ecs/service/ecs.tf
@@ -59,12 +59,16 @@ resource "aws_ecs_task_definition" "this" {
       "logConfiguration": {
         "logDriver": "awsfirelens",
         "options": {
-          "Name": "cloudwatch",
-          "region": "us-west-2",
-          "log_group_name": "${var.cloudwatch_logs_group_id}",
-          "auto_create_group": "false",
-          "log_stream_name": "${var.service_name}-service",
-          "retry_limit": "2"
+          "Name": "http",
+          "Host": "${var.oodle_log_collector_host}",
+          "Port": "443",
+          "URI": "/ingest/v1/logs",
+          "Header": "X-OODLE-INSTANCE-API-KEY ${var.oodle_instance}",
+          "Format": "json",
+          "Compress": "gzip",
+          "Json_date_key": "timestamp",
+          "Json_date_format": "iso8601",
+          "TLS": "On"
         }
       }
     },


### PR DESCRIPTION
### Note
Configuring firelens in task definition only (instead also using fluent-bit configuration file) cannot support multi-routing.