### PR TITLE
Ingest ECS logs to Oodle using otel collector

### DIFF
--- a/deploy/terraform/ecs/default/main.tf
+++ b/deploy/terraform/ecs/default/main.tf
@@ -59,4 +59,8 @@ module "retail_app_ecs" {
   mq_endpoint = module.dependencies.mq_broker_endpoint
   mq_username = module.dependencies.mq_user
   mq_password = module.dependencies.mq_password
+
+  oodle_api_key                   = var.oodle_api_key
+  oodle_endpoint                  = var.oodle_endpoint
+  oodle_instance                  = var.oodle_instance
 }

--- a/deploy/terraform/ecs/default/variables.tf
+++ b/deploy/terraform/ecs/default/variables.tf
@@ -8,3 +8,15 @@ variable "container_image_overrides" {
   default     = {}
   description = "Container image override object"
 }
+
+variable "oodle_api_key" {
+  type = string
+}
+
+variable "oodle_endpoint" {
+  type = string
+}
+
+variable "oodle_instance" {
+  type = string
+}

--- a/deploy/terraform/lib/dependencies/mq.tf
+++ b/deploy/terraform/lib/dependencies/mq.tf
@@ -13,7 +13,7 @@ resource "aws_mq_broker" "mq" {
   broker_name = "${var.environment_name}-orders-broker"
 
   engine_type         = "RabbitMQ"
-  engine_version      = "3.11.16"
+  engine_version      = "3.12.13"
   host_instance_type  = "mq.t3.micro"
   deployment_mode     = "SINGLE_INSTANCE"
   subnet_ids          = [var.subnet_ids[0]]

--- a/deploy/terraform/lib/ecs/assets.tf
+++ b/deploy/terraform/lib/ecs/assets.tf
@@ -10,7 +10,11 @@ module "assets_service" {
   public_subnet_ids               = var.public_subnet_ids
   tags                            = var.tags
   container_image                 = module.container_images.result.assets.url
+  otel_collector_image            = module.container_images.result.otel_collector.url
   service_discovery_namespace_arn = aws_service_discovery_private_dns_namespace.this.arn
   cloudwatch_logs_group_id        = aws_cloudwatch_log_group.ecs_tasks.id
   healthcheck_path                = "/health.html"
+  oodle_api_key                   = var.oodle_api_key
+  oodle_endpoint                  = var.oodle_endpoint
+  oodle_instance                  = var.oodle_instance
 }

--- a/deploy/terraform/lib/ecs/carts.tf
+++ b/deploy/terraform/lib/ecs/carts.tf
@@ -10,9 +10,13 @@ module "carts_service" {
   public_subnet_ids               = var.public_subnet_ids
   tags                            = var.tags
   container_image                 = module.container_images.result.cart.url
+  otel_collector_image            = module.container_images.result.otel_collector.url
   service_discovery_namespace_arn = aws_service_discovery_private_dns_namespace.this.arn
   cloudwatch_logs_group_id        = aws_cloudwatch_log_group.ecs_tasks.id
   healthcheck_path                = "/actuator/health"
+  oodle_api_key                   = var.oodle_api_key
+  oodle_endpoint                  = var.oodle_endpoint
+  oodle_instance                  = var.oodle_instance
 
   environment_variables = {
     CARTS_DYNAMODB_TABLENAME = var.carts_dynamodb_table_name

--- a/deploy/terraform/lib/ecs/catalog.tf
+++ b/deploy/terraform/lib/ecs/catalog.tf
@@ -10,8 +10,12 @@ module "catalog_service" {
   public_subnet_ids               = var.public_subnet_ids
   tags                            = var.tags
   container_image                 = module.container_images.result.catalog.url
+  otel_collector_image            = module.container_images.result.otel_collector.url
   service_discovery_namespace_arn = aws_service_discovery_private_dns_namespace.this.arn
   cloudwatch_logs_group_id        = aws_cloudwatch_log_group.ecs_tasks.id
+  oodle_api_key                   = var.oodle_api_key
+  oodle_endpoint                  = var.oodle_endpoint
+  oodle_instance                  = var.oodle_instance
 
   environment_variables = {
     DB_NAME = var.catalog_db_name

--- a/deploy/terraform/lib/ecs/checkout.tf
+++ b/deploy/terraform/lib/ecs/checkout.tf
@@ -10,8 +10,12 @@ module "checkout_service" {
   public_subnet_ids               = var.public_subnet_ids
   tags                            = var.tags
   container_image                 = module.container_images.result.checkout.url
+  otel_collector_image            = module.container_images.result.otel_collector.url
   service_discovery_namespace_arn = aws_service_discovery_private_dns_namespace.this.arn
   cloudwatch_logs_group_id        = aws_cloudwatch_log_group.ecs_tasks.id
+  oodle_api_key                   = var.oodle_api_key
+  oodle_endpoint                  = var.oodle_endpoint
+  oodle_instance                  = var.oodle_instance
 
   environment_variables = {
     REDIS_URL        = "redis://${var.checkout_redis_endpoint}:${var.checkout_redis_port}"

--- a/deploy/terraform/lib/ecs/orders.tf
+++ b/deploy/terraform/lib/ecs/orders.tf
@@ -10,9 +10,13 @@ module "orders_service" {
   public_subnet_ids               = var.public_subnet_ids
   tags                            = var.tags
   container_image                 = module.container_images.result.orders.url
+  otel_collector_image            = module.container_images.result.otel_collector.url
   service_discovery_namespace_arn = aws_service_discovery_private_dns_namespace.this.arn
   cloudwatch_logs_group_id        = aws_cloudwatch_log_group.ecs_tasks.id
   healthcheck_path                = "/actuator/health"
+  oodle_api_key                   = var.oodle_api_key
+  oodle_endpoint                  = var.oodle_endpoint
+  oodle_instance                  = var.oodle_instance
 
   environment_variables = {
     RETAIL_ORDERS_MESSAGING_PROVIDER = "rabbitmq"

--- a/deploy/terraform/lib/ecs/otel/otel-config-v1.yaml
+++ b/deploy/terraform/lib/ecs/otel/otel-config-v1.yaml
@@ -1,0 +1,46 @@
+extensions:
+  health_check:
+
+receivers:
+  fluentforward/socket:
+    endpoint: unix:///var/run/fluent.sock
+  fluentforward/tcp:
+    endpoint: 0.0.0.0:24284
+
+processors:
+  batch:
+  resourcedetection/ecs:
+    detectors: [env, ecs]
+    timeout: 2s
+    override: false
+  resource/service_name:
+    attributes:
+      - key: aws.ecs.service.name
+        from_attribute: aws.ecs.task.family
+        action: insert
+
+exporters:
+  otlphttp/oodle:
+    endpoint: "https://${OODLE_ENDPOINT}/ingest/otel"
+    headers:
+      X-OODLE-INSTANCE: "${OODLE_INSTANCE}"
+      X-API-KEY: "${OODLE_API_KEY}"
+    compression: gzip
+  awscloudwatchlogs:
+    region: "${AWS_REGION}"
+    log_group_name: "${CLOUDWATCH_LOG_GROUP}"
+    log_stream_name: "${CLOUDWATCH_LOG_STREAM}"
+
+service:
+  pipelines:
+    logs:
+      receivers:
+        - fluentforward/socket
+        - fluentforward/tcp
+      processors:
+        - batch
+        - resourcedetection/ecs
+        - resource/service_name
+      exporters:
+        - otlphttp/oodle
+        - awscloudwatchlogs

--- a/deploy/terraform/lib/ecs/otel/otel-config-v1.yaml
+++ b/deploy/terraform/lib/ecs/otel/otel-config-v1.yaml
@@ -18,6 +18,8 @@ processors:
       - key: aws.ecs.service.name
         from_attribute: aws.ecs.task.family
         action: insert
+      - key: aws.ecs.task.family
+        action: delete
 
 exporters:
   otlphttp/oodle:

--- a/deploy/terraform/lib/ecs/service/ecs.tf
+++ b/deploy/terraform/lib/ecs/service/ecs.tf
@@ -70,7 +70,7 @@ resource "aws_ecs_task_definition" "this" {
         },
         {
           "name": "CLOUDWATCH_LOG_STREAM",
-          "value": "${var.service_name}-application"
+          "value": "${var.service_name}-service"
         }
       ],
       "command": ["--config", "https://oodle-configs.s3.us-west-2.amazonaws.com/logs/ecs/otel/otel-config-v1.yaml"],
@@ -79,7 +79,7 @@ resource "aws_ecs_task_definition" "this" {
         "options": {
           "awslogs-group": "${var.cloudwatch_logs_group_id}",
           "awslogs-region": "${data.aws_region.current.name}",
-          "awslogs-stream-prefix": "${var.service_name}-otel"
+          "awslogs-stream-prefix": "${var.service_name}-service"
         }
       },
       "firelensConfiguration": {

--- a/deploy/terraform/lib/ecs/service/variables.tf
+++ b/deploy/terraform/lib/ecs/service/variables.tf
@@ -40,6 +40,10 @@ variable "container_image" {
   description = "Container image for the service"
 }
 
+variable "otel_collector_image" {
+  description = "Container image for the otel collector"
+}
+
 variable "service_discovery_namespace_arn" {
   description = "ARN of the service discovery namespace for Service Connect"
 }
@@ -76,4 +80,16 @@ variable "cloudwatch_logs_group_id" {
 variable "alb_target_group_arn" {
   description = "ARN of the ALB target group the ECS service should register tasks to"
   default     = ""
+}
+
+variable "oodle_api_key" {
+  description = "Oodle API key"
+}
+
+variable "oodle_endpoint" {
+  description = "Oodle log collector host"
+}
+
+variable "oodle_instance" {
+  description = "Oodle instance"
 }

--- a/deploy/terraform/lib/ecs/ui.tf
+++ b/deploy/terraform/lib/ecs/ui.tf
@@ -10,10 +10,14 @@ module "ui_service" {
   public_subnet_ids               = var.public_subnet_ids
   tags                            = var.tags
   container_image                 = module.container_images.result.ui.url
+  otel_collector_image            = module.container_images.result.otel_collector.url
   service_discovery_namespace_arn = aws_service_discovery_private_dns_namespace.this.arn
   cloudwatch_logs_group_id        = aws_cloudwatch_log_group.ecs_tasks.id
   healthcheck_path                = "/actuator/health"
   alb_target_group_arn            = element(module.alb.target_group_arns, 0)
+  oodle_api_key                   = var.oodle_api_key
+  oodle_endpoint                  = var.oodle_endpoint
+  oodle_instance                  = var.oodle_instance
 
   environment_variables = {
     ENDPOINTS_CATALOG  = "http://${module.catalog_service.ecs_service_name}"

--- a/deploy/terraform/lib/ecs/variables.tf
+++ b/deploy/terraform/lib/ecs/variables.tf
@@ -100,3 +100,15 @@ variable "mq_username" {
 variable "mq_password" {
   type = string
 }
+
+variable "oodle_api_key" {
+  type = string
+}
+
+variable "oodle_endpoint" {
+  type = string
+}
+
+variable "oodle_instance" {
+  type = string
+}

--- a/deploy/terraform/lib/images/main.tf
+++ b/deploy/terraform/lib/images/main.tf
@@ -19,4 +19,7 @@ locals {
 
   ui_default_image = "${local.default_repository}/retail-store-sample-ui:${local.default_tag}"
   ui_image         = try(var.container_image_overrides.ui, local.ui_default_image)
+
+  otel_collector_default_image = "${local.default_repository}/opentelemetry-collector-contrib:${local.default_tag}"
+  otel_collector_image         = try(var.container_image_overrides.otel_collector, local.otel_collector_default_image)
 }

--- a/deploy/terraform/lib/images/outputs.tf
+++ b/deploy/terraform/lib/images/outputs.tf
@@ -18,5 +18,8 @@ output "result" {
     ui = merge({
       url = local.ui_image
     }, zipmap(["repository", "tag"], split(":", local.ui_image)))
+    otel_collector = merge({
+      url = local.otel_collector_image
+    }, zipmap(["repository", "tag"], split(":", local.otel_collector_image)))
   }
 }


### PR DESCRIPTION
## Why
Support using otel collector to send ECS Fargate logs to multiple destinations, including Oodle and Cloudwatch Logs. 