### PR TITLE
Some improvements on ecs fluent-bit ingestion

### DIFF
--- a/deploy/terraform/lib/dependencies/mq.tf
+++ b/deploy/terraform/lib/dependencies/mq.tf
@@ -13,7 +13,7 @@ resource "aws_mq_broker" "mq" {
   broker_name = "${var.environment_name}-orders-broker"
 
   engine_type         = "RabbitMQ"
-  engine_version      = "3.11.16"
+  engine_version      = "3.12.13"
   host_instance_type  = "mq.t3.micro"
   deployment_mode     = "SINGLE_INSTANCE"
   subnet_ids          = [var.subnet_ids[0]]

--- a/deploy/terraform/lib/ecs/service/ecs.tf
+++ b/deploy/terraform/lib/ecs/service/ecs.tf
@@ -96,7 +96,7 @@ resource "aws_ecs_task_definition" "this" {
     },
     {
       "name": "log-router",
-      "image": "public.ecr.aws/aws-observability/aws-for-fluent-bit:init-latest",
+      "image": "public.ecr.aws/aws-observability/aws-for-fluent-bit:init-2.32.5.20250305",
       "essential": true,
       "memory": 200,
       "environment": [

--- a/deploy/terraform/lib/ecs/service/ecs.tf
+++ b/deploy/terraform/lib/ecs/service/ecs.tf
@@ -59,24 +59,24 @@ resource "aws_ecs_task_definition" "this" {
       "logConfiguration": {
         "logDriver": "awsfirelens",
         "options": {
-          "Name": "cloudwatch",
+          "Name": "cloudwatch_logs",
           "region": "us-west-2",
           "log_group_name": "${var.cloudwatch_logs_group_id}",
           "auto_create_group": "false",
-          "log_stream_name": "${var.service_name}-service",
+          "log_stream_name": "${var.service_name}-service/application/$${ECS_TASK_ID}",
           "retry_limit": "2"
         }
       }
     },
     {
       "name": "config-init",
-      "image": "alpine:latest",
+      "image": "public.ecr.aws/docker/library/alpine:latest",
       "essential": false,
       "memoryReservation": 64,
       "command": [
-        "wget",
-        "-O", "/oodle/fluent-bit.conf",
-        "https://oodle-configs.s3.us-west-2.amazonaws.com/logs/ecs/fluent-bit/fluent-bit.conf"
+        "sh",
+        "-c",
+        "apk add --no-cache ca-certificates wget && wget -O /oodle/fluent-bit.conf https://oodle-configs.s3.us-west-2.amazonaws.com/logs/ecs/fluent-bit/fluent-bit.conf"
       ],
       "mountPoints": [
         {
@@ -90,13 +90,13 @@ resource "aws_ecs_task_definition" "this" {
         "options": {
           "awslogs-group": "${var.cloudwatch_logs_group_id}",
           "awslogs-region": "${data.aws_region.current.name}",
-          "awslogs-stream-prefix": "${var.service_name}-init"
+          "awslogs-stream-prefix": "${var.service_name}-service"
         }
       }
     },
     {
       "name": "log-router",
-      "image": "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
+      "image": "public.ecr.aws/aws-observability/aws-for-fluent-bit:init-latest",
       "essential": true,
       "memory": 200,
       "environment": [
@@ -105,7 +105,7 @@ resource "aws_ecs_task_definition" "this" {
           "value": "${var.oodle_api_key}"
         },
         {
-          "name": "OODLE_LOG_COLLECTOR_HOST",
+          "name": "OODLE_ENDPOINT",
           "value": "${var.oodle_log_collector_host}"
         },
         {

--- a/deploy/terraform/lib/ecs/service/fluent-bit-v1.conf
+++ b/deploy/terraform/lib/ecs/service/fluent-bit-v1.conf
@@ -1,7 +1,7 @@
 [OUTPUT]
     Name        http
     Match       application-firelens*
-    Host        ${OODLE_LOG_COLLECTOR_HOST}
+    Host        ${OODLE_ENDPOINT}
     Port        443
     URI         /ingest/v1/logs
     Header      X-OODLE-INSTANCE ${OODLE_INSTANCE}

--- a/deploy/terraform/lib/ecs/service/iam.tf
+++ b/deploy/terraform/lib/ecs/service/iam.tf
@@ -83,10 +83,7 @@ resource "aws_iam_policy" "firelens_cloudwatch" {
           "logs:PutLogEvents",
           "logs:DescribeLogStreams"
         ]
-        Resource = [
-          "arn:aws:logs:*:*:log-group:retail-store-ecs-tasks:*",
-          "arn:aws:logs:*:*:log-group:retail-store-ecs-tasks:log-stream:*"
-        ]
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
D-1662

* Use versioned config file
* Use OODLE_ENDPOINT env var
* Use more performant plugin `cloudwatch_logs` for cloudwatch
* Use `aws-for-fluent-bit:init-latest` image to get more ECS metadata
* Add ca-certificates for https in config-init